### PR TITLE
Fix Chart.js usage and secure CDN loading

### DIFF
--- a/JobFitAI-Website/index.html
+++ b/JobFitAI-Website/index.html
@@ -118,9 +118,15 @@
   </footer>
 
   <!-- Load external libraries (Three.js, Vanta.js, Chart.js) and then our script -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r121/three.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/vanta@latest/dist/vanta.globe.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r121/three.min.js"
+    integrity="sha384-DXar47anhP2p0NKLdo4cUCrnUtBBp/r91y336ez5hAeL8XPMqKND66/jv8ocrYAL"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vanta@0.5.24/dist/vanta.globe.min.js"
+    integrity="sha384-HiLexGd74hcQ6g/RxA2NsDBwbmX+PmKsMBVLRsUWFwFJth+ybhAQ6N90hz80HeSD"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"
+    integrity="sha384-e6nUZLBkQ86NJ6TVVKAeSaK8jWa3NhkYWZFomE39AvDbQWeie9PlQqM3pmYW5d1g"
+    crossorigin="anonymous"></script>
   <script src="script.js"></script>
 </body>
 </html>

--- a/JobFitAI-Website/script.js
+++ b/JobFitAI-Website/script.js
@@ -15,7 +15,8 @@ VANTA.GLOBE({
 
 // Setup Chart.js radar chart for Skill Profile visualization
 const ctx = document.getElementById('skillChart').getContext('2d');
-new Chart(ctx, {
+// Store chart instance for potential future updates or interactions
+const skillChart = new Chart(ctx, {
   type: 'radar',
   data: {
     labels: ['Technical Skills', 'Soft Skills', 'Domain Knowledge'],


### PR DESCRIPTION
## Summary
- store radar chart instance to avoid unused constructor
- pin CDN versions and add SRI integrity checks

## Testing
- `pnpm run lint`
- `pnpm run typecheck` *(fails: Property/Module errors)*
- `pnpm run test`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_b_687a75c399a4832eb9c9dc83ebde1184