### PR TITLE
Add SRI hashes for CDN scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -474,9 +474,9 @@
     <!-- All JavaScript libraries and application code is embedded here -->
     
     <!-- 1. Import Libraries from CDN -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.9.1/gsap.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js" integrity="sha384-CI3ELBVUz9XQO+97x6nwMDPosPR5XvsxW2ua7N1Xeygeh1IxtgqtCkGfQY9WWdHu" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.9.1/gsap.min.js" integrity="sha384-lI86CGWNchoT9leGBpVR41iGrRTRbHRDsPI4Zo/atPOIodjl8YyDaVefcpgkCg4u" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js" integrity="sha384-e6nUZLBkQ86NJ6TVVKAeSaK8jWa3NhkYWZFomE39AvDbQWeie9PlQqM3pmYW5d1g" crossorigin="anonymous"></script>
 
     <!-- 2. Application Logic -->
     <script>


### PR DESCRIPTION
## Summary
- add integrity checks and crossorigin attributes for CDN scripts
- pin Chart.js version for consistent builds

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_b_687a76996e98832e8350f4588dc357a1