### PR TITLE
refactor: typed resume parser

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -43,3 +43,4 @@ flowchart LR
 - The current monolithic Express API will be containerized and scaled in EKS behind an ALB with TLS.
 - Persistent state (PostgreSQL, Redis, S3) will leverage managed AWS services.
 - AI integrations will be abstracted through a provider-agnostic interface.
+- Resume parsing produces a typed structure (contact, skills, experience, education) enabling consistent processing across services.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ JobFit AI is a comprehensive web application designed to help job seekers optimi
 
 ### Resume Processing Pipeline
 1. **File Upload**: Supports PDF, DOCX, TXT, MD, RTF, and ODT formats (10MB limit)
-2. **Content Parsing**: Extracts structured data including contact info, experience, education, and skills
+2. **Content Parsing**: Extracts strongly typed data including contact info, experience, education, and skills for reliable downstream processing
 3. **ATS Scoring**: Analyzes resume compatibility with Applicant Tracking Systems
 4. **Skill Profiling**: Categorizes and evaluates technical, soft, and domain-specific skills
 

--- a/server/services/parserUtils.ts
+++ b/server/services/parserUtils.ts
@@ -74,7 +74,7 @@ export function extractParsedData(text: string): ParsedResume {
     const lines = expMatch[1].trim().split(/\r?\n/);
     let current: ExperienceEntry | null = null;
     lines.forEach(line => {
-      const headerMatch = line.match(/^(.*)\|(.+)\|(.*)$/);
+      const headerMatch = line.match(/^([^|]+)\s*\|\s*([^|]+)\s*\|\s*(.*)$/);
       if (headerMatch) {
         if (current) parsed.experience.push(current);
         const [_, title, company, dates] = headerMatch;

--- a/server/services/parserUtils.ts
+++ b/server/services/parserUtils.ts
@@ -69,7 +69,7 @@ export function extractParsedData(text: string): ParsedResume {
   const parsed: ParsedResume = { contact, skills, experience: [], education: [] };
 
   // Experience
-  const expMatch = text.match(/PROFESSIONAL EXPERIENCE([\s\S]*?)\nEDUCATION/i);
+  const expMatch = text.match(/PROFESSIONAL EXPERIENCE([\s\S]*?)(?:\n[A-Z0-9 &()]+\n|$)/i);
   if (expMatch) {
     const lines = expMatch[1].trim().split(/\r?\n/);
     let current: ExperienceEntry | null = null;

--- a/server/services/parserUtils.ts
+++ b/server/services/parserUtils.ts
@@ -42,11 +42,11 @@ export function extractParsedData(text: string): ParsedResume {
 
   const contact: ContactInfo = {
     name: contactBlock.split(/\r?\n/).find(line => line.trim() !== '') || '',
-    email: ((contactBlock.match(/[\w.+-]+@[\w-]+\.[\w.-]+/) || [''])[0]).trim(),
-    phone: ((contactBlock.match(/(?:\+?[\d(][\d\s-.()]{7,}\d)/) || [''])[0]).trim(),
-    location: (contactBlock.match(/Location:\s*(.*)/i) || ['', ''])[1].trim(),
-    linkedin: (contactBlock.match(/LinkedIn:\s*(.*)/i) || ['', ''])[1].trim(),
-    website: (contactBlock.match(/Website:\s*(.*)/i) || ['', ''])[1].trim(),
+    email: (contactBlock.match(/[\w.+-]+@[\w-]+\.[\w.-]+/)?.[0] ?? '').trim(),
+    phone: (contactBlock.match(/(?:\+?[\d(][\d\s-.()]{7,}\d)/)?.[0] ?? '').trim(),
+    location: (contactBlock.match(/Location:\s*(.*)/i)?.[1] ?? '').trim(),
+    linkedin: (contactBlock.match(/LinkedIn:\s*(.*)/i)?.[1] ?? '').trim(),
+    website: (contactBlock.match(/Website:\s*(.*)/i)?.[1] ?? '').trim(),
   };
 
   // Skills

--- a/server/services/parserUtils.ts
+++ b/server/services/parserUtils.ts
@@ -1,14 +1,49 @@
 /**
+ * Structured contact information.
+ */
+export interface ContactInfo {
+  name: string;
+  email: string;
+  phone: string;
+  location: string;
+  linkedin: string;
+  website: string;
+}
+
+/**
+ * Work experience entry.
+ */
+export interface ExperienceEntry {
+  title: string;
+  company: string;
+  startDate: string;
+  endDate: string;
+  details: string[];
+}
+
+/**
+ * Parsed resume structure returned by {@link extractParsedData}.
+ */
+export interface ParsedResume {
+  contact: ContactInfo;
+  skills: string[];
+  experience: ExperienceEntry[];
+  education: string[];
+}
+
+/**
  * Extract structured fields from resume text.
  */
-export function extractParsedData(text: string) {
-  const parsed: Record<string, any> = {};
-  // Contact info
-  const contactBlock = text.split(/PROFESSIONAL SUMMARY/i)[0];
-  parsed.contact = {
+export function extractParsedData(text: string): ParsedResume {
+  // Determine contact section – fall back to the first paragraph if
+  // a "Professional Summary" heading is absent.
+  const summarySplit = text.split(/PROFESSIONAL SUMMARY/i);
+  const contactBlock = summarySplit.length > 1 ? summarySplit[0] : text.split(/\r?\n{2,}/)[0];
+
+  const contact: ContactInfo = {
     name: contactBlock.split(/\r?\n/).find(line => line.trim() !== '') || '',
-    email: (contactBlock.match(/[\w.+-]+@[\w-]+\.[\w.-]+/) || [''])[0],
-    phone: (contactBlock.match(/(?:\+?[\d(][\d\s-.()]{7,}\d)/) || [''])[0],
+    email: ((contactBlock.match(/[\w.+-]+@[\w-]+\.[\w.-]+/) || [''])[0]).trim(),
+    phone: ((contactBlock.match(/(?:\+?[\d(][\d\s-.()]{7,}\d)/) || [''])[0]).trim(),
     location: (contactBlock.match(/Location:\s*(.*)/i) || ['', ''])[1].trim(),
     linkedin: (contactBlock.match(/LinkedIn:\s*(.*)/i) || ['', ''])[1].trim(),
     website: (contactBlock.match(/Website:\s*(.*)/i) || ['', ''])[1].trim(),
@@ -30,21 +65,27 @@ export function extractParsedData(text: string) {
         }
       });
   }
-  parsed.skills = skills;
+
+  const parsed: ParsedResume = { contact, skills, experience: [], education: [] };
 
   // Experience
   const expMatch = text.match(/PROFESSIONAL EXPERIENCE([\s\S]*?)\nEDUCATION/i);
-  parsed.experience = [];
   if (expMatch) {
     const lines = expMatch[1].trim().split(/\r?\n/);
-    let current: any = null;
+    let current: ExperienceEntry | null = null;
     lines.forEach(line => {
       const headerMatch = line.match(/^(.*)\|(.+)\|(.*)$/);
       if (headerMatch) {
         if (current) parsed.experience.push(current);
         const [_, title, company, dates] = headerMatch;
         const [start, end] = dates.split('-').map(s => s.trim());
-        current = { title: title.trim(), company: company.trim(), startDate: start, endDate: end, details: [] };
+        current = {
+          title: title.trim(),
+          company: company.trim(),
+          startDate: start,
+          endDate: end,
+          details: [],
+        };
       } else if (line.startsWith('•') && current) {
         current.details.push(line.replace(/^•\s*/, '').trim());
       }
@@ -54,7 +95,6 @@ export function extractParsedData(text: string) {
 
   // Education
   const eduMatch = text.match(/EDUCATION([\s\S]*?)(?:\n[A-Z0-9 &()]+\n|$)/);
-  parsed.education = [];
   if (eduMatch) {
     eduMatch[1]
       .trim()


### PR DESCRIPTION
## Summary
- define explicit ParsedResume and related types for resume parsing
- improve contact block detection and trim email/phone
- document typed parsing in README and ARCHITECTURE

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a602a9ef988330955b5c450d4eb28a