### PR TITLE
feat: normalize recommendations and central error handling

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -43,3 +43,6 @@ flowchart LR
 - The current monolithic Express API will be containerized and scaled in EKS behind an ALB with TLS.
 - Persistent state (PostgreSQL, Redis, S3) will leverage managed AWS services.
 - AI integrations will be abstracted through a provider-agnostic interface.
+- Resume parsing produces a typed structure (contact, skills, experience, education) enabling consistent processing across services.
+- Express middleware centralizes error handling, logging failures and returning JSON without crashing the server. Stack traces are exposed only in development.
+- Role recommendation fit scores are normalized to 0–100 and textual fields are trimmed to guard against malformed AI responses.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ JobFit AI is a comprehensive web application designed to help job seekers optimi
 - **Database Provider**: Neon Database (serverless PostgreSQL)
 - **File Processing**: Multer for file upload handling
 - **Session Management**: Built-in storage system with memory-based implementation
+- **Error Handling**: Centralized middleware logs errors, returns JSON responses, and exposes stack traces in development
 
 ### Development Environment
 - **Platform**: Node.js 20, web, and PostgreSQL 16 modules
@@ -38,12 +39,12 @@ JobFit AI is a comprehensive web application designed to help job seekers optimi
 
 ### Resume Processing Pipeline
 1. **File Upload**: Supports PDF, DOCX, TXT, MD, RTF, and ODT formats (10MB limit)
-2. **Content Parsing**: Extracts structured data including contact info, experience, education, and skills
+2. **Content Parsing**: Extracts strongly typed data including contact info, experience, education, and skills for reliable downstream processing
 3. **ATS Scoring**: Analyzes resume compatibility with Applicant Tracking Systems
 4. **Skill Profiling**: Categorizes and evaluates technical, soft, and domain-specific skills
 
 ### AI-Powered Features
-- **Role Recommendations**: Matches user skills to relevant job positions using semantic analysis
+- **Role Recommendations**: Matches user skills to relevant job positions using semantic analysis with fit scores normalized to 0–100
 - **Resume Tailoring**: Customizes resume content based on specific job descriptions
 - **Improvement Suggestions**: Provides actionable feedback for resume optimization
 
@@ -53,7 +54,7 @@ JobFit AI is a comprehensive web application designed to help job seekers optimi
 - **Resume Builder**: Step-by-step form for manual resume creation with validation
 - **Resume Cards**: Interactive cards with optimization, tailoring, and export actions
 - **Skill Profile**: Visual representation of user competencies
-- **Role Recommendations**: Displays job matches with fit scores
+- **Role Recommendations**: Displays job matches with fit scores normalized to 0–100
 - **Tailoring Workspace**: Interactive editor for customizing resumes
 - **Export Modal**: Multi-format download system with optimized versions
 - **Optimization Modal**: Visual score comparison and improvement tracking
@@ -76,7 +77,7 @@ JobFit AI is a comprehensive web application designed to help job seekers optimi
 ### Database Schema
 - **Users**: Authentication and user management
 - **Resumes**: Original files, parsed content, and processing status
-- **Role Recommendations**: AI-generated job matches with scoring
+- **Role Recommendations**: AI-generated job matches with normalized 0–100 scoring
 - **Tailored Resumes**: Customized versions with improvement tracking
 - **Activities**: User action logging and analytics
 

--- a/server/error.ts
+++ b/server/error.ts
@@ -1,0 +1,16 @@
+import { type Request, type Response, type NextFunction } from 'express';
+import { log } from './vite';
+
+export function errorHandler(err: any, _req: Request, res: Response, _next: NextFunction) {
+  const status = err.status || err.statusCode || 500;
+  const message = err.message || 'Internal Server Error';
+  const body: Record<string, any> = { message };
+
+  if (process.env.NODE_ENV !== 'production' && err.stack) {
+    body.stack = err.stack;
+    console.error(err.stack);
+  }
+
+  log(`${status} ${message}`, 'error');
+  res.status(status).json(body);
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,7 +1,8 @@
-import express, { type Request, Response, NextFunction } from "express";
+import express from "express";
 import router from "./routes";
 import http from "http";
 import { setupVite, serveStatic, log } from "./vite";
+import { errorHandler } from "./error";
 
 const app = express();
 app.use(express.json());
@@ -41,13 +42,7 @@ app.use((req, res, next) => {
   const server = http.createServer(app);
   app.use(router);
 
-  app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
-    const status = err.status || err.statusCode || 500;
-    const message = err.message || "Internal Server Error";
-
-    res.status(status).json({ message });
-    throw err;
-  });
+  app.use(errorHandler);
 
   // importantly only setup vite in development and after
   // setting up all the other routes so the catch-all route

--- a/server/services/parserUtils.ts
+++ b/server/services/parserUtils.ts
@@ -1,14 +1,49 @@
 /**
+ * Structured contact information.
+ */
+export interface ContactInfo {
+  name: string;
+  email: string;
+  phone: string;
+  location: string;
+  linkedin: string;
+  website: string;
+}
+
+/**
+ * Work experience entry.
+ */
+export interface ExperienceEntry {
+  title: string;
+  company: string;
+  startDate: string;
+  endDate: string;
+  details: string[];
+}
+
+/**
+ * Parsed resume structure returned by {@link extractParsedData}.
+ */
+export interface ParsedResume {
+  contact: ContactInfo;
+  skills: string[];
+  experience: ExperienceEntry[];
+  education: string[];
+}
+
+/**
  * Extract structured fields from resume text.
  */
-export function extractParsedData(text: string) {
-  const parsed: Record<string, any> = {};
-  // Contact info
-  const contactBlock = text.split(/PROFESSIONAL SUMMARY/i)[0];
-  parsed.contact = {
+export function extractParsedData(text: string): ParsedResume {
+  // Determine contact section – fall back to the first paragraph if
+  // a "Professional Summary" heading is absent.
+  const summarySplit = text.split(/PROFESSIONAL SUMMARY/i);
+  const contactBlock = summarySplit.length > 1 ? summarySplit[0] : text.split(/\r?\n{2,}/)[0];
+
+  const contact: ContactInfo = {
     name: contactBlock.split(/\r?\n/).find(line => line.trim() !== '') || '',
-    email: (contactBlock.match(/[\w.+-]+@[\w-]+\.[\w.-]+/) || [''])[0],
-    phone: (contactBlock.match(/(?:\+?[\d(][\d\s-.()]{7,}\d)/) || [''])[0],
+    email: ((contactBlock.match(/[\w.+-]+@[\w-]+\.[\w.-]+/) || [''])[0]).trim(),
+    phone: ((contactBlock.match(/(?:\+?[\d(][\d\s-.()]{7,}\d)/) || [''])[0]).trim(),
     location: (contactBlock.match(/Location:\s*(.*)/i) || ['', ''])[1].trim(),
     linkedin: (contactBlock.match(/LinkedIn:\s*(.*)/i) || ['', ''])[1].trim(),
     website: (contactBlock.match(/Website:\s*(.*)/i) || ['', ''])[1].trim(),
@@ -30,21 +65,27 @@ export function extractParsedData(text: string) {
         }
       });
   }
-  parsed.skills = skills;
+
+  const parsed: ParsedResume = { contact, skills, experience: [], education: [] };
 
   // Experience
   const expMatch = text.match(/PROFESSIONAL EXPERIENCE([\s\S]*?)\nEDUCATION/i);
-  parsed.experience = [];
   if (expMatch) {
     const lines = expMatch[1].trim().split(/\r?\n/);
-    let current: any = null;
+    let current: ExperienceEntry | null = null;
     lines.forEach(line => {
       const headerMatch = line.match(/^(.*)\|(.+)\|(.*)$/);
       if (headerMatch) {
         if (current) parsed.experience.push(current);
         const [_, title, company, dates] = headerMatch;
         const [start, end] = dates.split('-').map(s => s.trim());
-        current = { title: title.trim(), company: company.trim(), startDate: start, endDate: end, details: [] };
+        current = {
+          title: title.trim(),
+          company: company.trim(),
+          startDate: start,
+          endDate: end,
+          details: [],
+        };
       } else if (line.startsWith('•') && current) {
         current.details.push(line.replace(/^•\s*/, '').trim());
       }
@@ -54,7 +95,6 @@ export function extractParsedData(text: string) {
 
   // Education
   const eduMatch = text.match(/EDUCATION([\s\S]*?)(?:\n[A-Z0-9 &()]+\n|$)/);
-  parsed.education = [];
   if (eduMatch) {
     eduMatch[1]
       .trim()

--- a/server/services/recommender.test.ts
+++ b/server/services/recommender.test.ts
@@ -23,6 +23,41 @@ describe('parseRecommendations', () => {
     ]);
   });
 
+  it('normalizes fitScore and trims fields', () => {
+    const text = JSON.stringify([
+      {
+        jobTitle: '  Engineer  ',
+        companyName: ' Corp ',
+        fitScore: 150,
+        description: ' Build stuff ',
+        source: ' ai ',
+      },
+      {
+        jobTitle: 'Intern',
+        companyName: 'Startup',
+        fitScore: -20,
+        description: 'Entry role',
+        source: 'external',
+      },
+    ]);
+    expect(parseRecommendations(text)).toEqual([
+      {
+        jobTitle: 'Engineer',
+        companyName: 'Corp',
+        fitScore: 100,
+        description: 'Build stuff',
+        source: 'ai',
+      },
+      {
+        jobTitle: 'Intern',
+        companyName: 'Startup',
+        fitScore: 0,
+        description: 'Entry role',
+        source: 'external',
+      },
+    ]);
+  });
+
   it('throws on invalid data', () => {
     expect(() => parseRecommendations('not json')).toThrow();
   });

--- a/server/services/recommender.ts
+++ b/server/services/recommender.ts
@@ -18,11 +18,11 @@ export function parseRecommendations(content: string): Recommendation[] {
     const parsed = JSON.parse(content);
     if (!Array.isArray(parsed)) throw new Error();
     return parsed.map((r) => ({
-      jobTitle: String(r.jobTitle ?? ''),
-      companyName: String(r.companyName ?? ''),
-      fitScore: Number(r.fitScore) || 0,
-      description: String(r.description ?? ''),
-      source: String(r.source ?? 'ai'),
+      jobTitle: String(r.jobTitle ?? '').trim(),
+      companyName: String(r.companyName ?? '').trim(),
+      fitScore: Math.min(100, Math.max(0, Number(r.fitScore) || 0)),
+      description: String(r.description ?? '').trim(),
+      source: String(r.source ?? 'ai').trim(),
     }));
   } catch {
     throw new Error('Invalid AI response format');


### PR DESCRIPTION
## Summary
- define explicit ParsedResume and related types for resume parsing
- clamp AI recommendation fit scores between 0–100, trim text fields, and add tests
- centralize Express error handling with logging and optional stack traces
- document error handling and normalized fit-score behavior in README and architecture

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a602a9ef988330955b5c450d4eb28a